### PR TITLE
Avoid hard wrap in markdown files.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,88 +1,41 @@
 # Contributing to Pony Patterns
 
-Hi there! Thanks for your interest in contributing to Pony Patterns. The book is
-being developed in Markdown and hosted at 
-[Gitbook](https://www.gitbook.com/book/ponylang/pony-patterns/details). We
-welcome external contributors. In fact, we encourage them.
+Hi there! Thanks for your interest in contributing to Pony Patterns. The book is being developed in Markdown and hosted at  [Gitbook](https://www.gitbook.com/book/ponylang/pony-patterns/details). We welcome external contributors. In fact, we encourage them.
 
-Please note, that by submitting any content to the Pony Patterns book you are
-agreeing that it can be licensed under our [license](LICENSE.md). Furthermore,
-you are testifying that you own the copyright to the submitted content and
-indemnify Pony Patterns from any copyright claim that might result from your not
-being the authorized copyright holder.
+Please note, that by submitting any content to the Pony Patterns book you are agreeing that it can be licensed under our [license](LICENSE.md). Furthermore, you are testifying that you own the copyright to the submitted content and indemnify Pony Patterns from any copyright claim that might result from your not being the authorized copyright holder.
 
 ## How to format your Pattern
 
-Pony Patterns is a series of cookbook style recipes. What does this mean? Each
-section of the book should be focused on solving a specific problem in Pony.
-Additionally, it should follow the pattern "Problem" -> "Solution" ->
-"Discussion". 
+Pony Patterns is a series of cookbook style recipes. What does this mean? Each section of the book should be focused on solving a specific problem in Pony. Additionally, it should follow the pattern "Problem" -> "Solution" -> "Discussion".
 
-"Problem" should be centered around what we are trying to accomplish. Give some
-background on why a person might want to read this pattern. Keep it reasonably
-short. Most people will find the pattern they need by scanning through the
-problem sections. They might also find it by searching so make sure to try and
-include like keywords in the natural flow of your description.
+"Problem" should be centered around what we are trying to accomplish. Give some background on why a person might want to read this pattern. Keep it reasonably short. Most people will find the pattern they need by scanning through the problem sections. They might also find it by searching so make sure to try and include like keywords in the natural flow of your description.
 
-"Solution" should give code that solves the problem and then breaks it down into
-smaller chunks for discussion of what the individual section of code do. You
-don't have to cover every section of code, just the parts that are tricky or
-specific to the solution. Keep the code as minimal as possible and focused on
-the problem at hand.
+"Solution" should give code that solves the problem and then breaks it down into smaller chunks for discussion of what the individual section of code do. You don't have to cover every section of code, just the parts that are tricky or specific to the solution. Keep the code as minimal as possible and focused on the problem at hand.
 
-"Discussion" should cover any additional content that might be of interest, what
-other solutions the reader might want to look at and any general conclusions to
-be drawn. Is the solution slow? Potentially hard to maintain? That should be
-covered as part of "Discussion".
+"Discussion" should cover any additional content that might be of interest, what other solutions the reader might want to look at and any general conclusions to be drawn. Is the solution slow? Potentially hard to maintain? That should be covered as part of "Discussion".
 
-Each pattern should start with the name of pattern as a level one header: `#` in
-Markdown. With "Problem", "Solution" and "Discussion" each as second level
-headers: `##`. If you need to have any subsections, make them a third level
-heading: `###`. If you find yourself reaching for a forth level heading, stop
-and figure out a different way to present the info in that section.
+Each pattern should start with the name of pattern as a level one header: `#` in Markdown. With "Problem", "Solution" and "Discussion" each as second level headers: `##`. If you need to have any subsections, make them a third level heading: `###`. If you find yourself reaching for a forth level heading, stop and figure out a different way to present the info in that section.
 
-Please make sure to keep any individual line under 80 characters except in
-instance where that would break link with the markdown (which only happens if
-the linked text and url are more than 76 characters).
+Avoid hard-wrapping lines within paragraphs (using line breaks in the middle of or between sentences to make lines shorter than a certain length). Instead, turn on soft-wrapping in your editor and expect the documentation renderer to let the text flow to the width of the container.
 
 ## Where to put your pattern
 
-All patterns go in the top level of the repo within a directory for
-the appropriate section. If an appropriate section doesn't exist, create one and
-then add pattern within that directory. For example, to add a new section called
-`Networking`, you'd create a new folder `networking` then you can add your
-pattern to the directory. If you are creating a new section, add an `index.md`
-file that has the name of section as a level one entry: `#` in Markdown as well
-as description of the type of patterns to be found in the section.
+All patterns go in the top level of the repo within a directory for the appropriate section. If an appropriate section doesn't exist, create one and then add pattern within that directory. For example, to add a new section called `Networking`, you'd create a new folder `networking` then you can add your pattern to the directory. If you are creating a new section, add an `index.md` file that has the name of section as a level one entry: `#` in Markdown as well as description of the type of patterns to be found in the section.
 
 ## How to update the Table of Contents
 
-Table of contents is handled by the `Summary.md` file. Each section of the book
-will appear as a top level item in the list contained in `Summary.md`. Each
-pattern in turn appears as sub item beneath that. If you added a new section,
-don't forget to link to both the section `index.md` as well as the content for
-your pattern.
+Table of contents is handled by the `Summary.md` file. Each section of the book will appear as a top level item in the list contained in `Summary.md`. Each pattern in turn appears as sub item beneath that. If you added a new section, don't forget to link to both the section `index.md` as well as the content for your pattern.
 
 ## How to submit a pattern
 
-Once your content is done, please open a pull request against this repo with
-your changes. Based on the state of your particular PR, a number of requests for
-change might be requested:
+Once your content is done, please open a pull request against this repo with your changes. Based on the state of your particular PR, a number of requests for change might be requested:
 
 * Changes to the content
 * Change to where the content appears in the Table of Contents
 * Change to where the markdown file for the pattern is stored in the repo
 
-Be sure to keep your PR to a single pattern. If you are working on multiple
-patterns, make sure they are each on their own branch and that before creating a
-new branch that you are on the master branch (others multiple patterns might
-end up in your pull request). Each PR should be for a single logical change. We
-request that you create a good commit messages as laid out in 
-['How to Write a Git Commit Message'](http://chris.beams.io/posts/git-commit/).
+Be sure to keep your PR to a single pattern. If you are working on multiple patterns, make sure they are each on their own branch and that before creating a new branch that you are on the master branch (others multiple patterns might end up in your pull request). Each PR should be for a single logical change. We request that you create a good commit messages as laid out in  ['How to Write a Git Commit Message'](http://chris.beams.io/posts/git-commit/).
 
-If your PR is for a single logical change (which is should be) but spans
-multiple commits, we'll ask you to squash them into a single commit before we
-merge. Steve Klabnik wrote a handy guide for that: 
-[How to squash commits in a GitHub pull request](http://blog.steveklabnik.com/posts/2012-11-08-how-to-squash-commits-in-a-github-pull-request).
+If your PR is for a single logical change (which is should be) but spans multiple commits, we'll ask you to squash them into a single commit before we merge. Steve Klabnik wrote a handy guide for that:  [How to squash commits in a GitHub pull request](http://blog.steveklabnik.com/posts/2012-11-08-how-to-squash-commits-in-a-github-pull-request).
 
 

--- a/async/index.md
+++ b/async/index.md
@@ -1,6 +1,3 @@
 # Async patterns
 
-Patterns for dealing with the asynchronous nature of Pony. Unlike most
-languages, Pony has *zero* blocking operations. This can make simple everyday
-problems difficult until you know how to deal with them. If your problem has you
-wanting blocking operations, this is the chapter for you.
+Patterns for dealing with the asynchronous nature of Pony. Unlike most languages, Pony has *zero* blocking operations. This can make simple everyday problems difficult until you know how to deal with them. If your problem has you wanting blocking operations, this is the chapter for you.

--- a/async/waiting.md
+++ b/async/waiting.md
@@ -2,22 +2,13 @@
 
 ## Problem
 
-Here's the problem: you're writing an application that needs to execute an
-action every few seconds. In a language with blocking operations, I could just 
-call sleep and be done with it. It might not be the most elegant solution but 
-it would work. In Pony, no such obvious solution exists.  One of Pony's key 
-features is there are no blocking operations. It's a bit of a riddle: how do you
-wait when you can't wait? 
+Here's the problem: you're writing an application that needs to execute an action every few seconds. In a language with blocking operations, I could just call sleep and be done with it. It might not be the most elegant solution but it would work. In Pony, no such obvious solution exists.  One of Pony's key features is there are no blocking operations. It's a bit of a riddle: how do you wait when you can't wait?
 
 ## Solution
 
-You want to use the [Time package](http://www.ponylang.org/ponyc/time--index/).
-In particular, the [Timer](http://www.ponylang.org/ponyc/time-Timer/) and 
-[Timers](http://www.ponylang.org/ponyc/time-Timers/) types.
+You want to use the [Time package](http://www.ponylang.org/ponyc/time--index/). In particular, the [Timer](http://www.ponylang.org/ponyc/time-Timer/) and [Timers](http://www.ponylang.org/ponyc/time-Timers/) types.
 
-A timer allows you to execute code at set intervals. Let's walk through using a
-timer. Below is a simple application that prints out a number to the console
-every 5 seconds until someone terminates the program:
+A timer allows you to execute code at set intervals. Let's walk through using a timer. Below is a simple application that prints out a number to the console every 5 seconds until someone terminates the program:
 
 ```pony
 use "time"
@@ -45,8 +36,7 @@ class NumberGenerator is TimerNotify
     true
 ```
 
-Zooming in on the key bits, we first set up our timers, create one and add it 
-to our set of timers:
+Zooming in on the key bits, we first set up our timers, create one and add it to our set of timers:
 
 ```pony
     let timers = Timers
@@ -54,10 +44,7 @@ to our set of timers:
     timers(consume timer)
 ```
 
-The Timer constructor takes 3 arguments, the class to notify, how long until 
-our timer expires and how often to fire. In our example code an instance of 
-NumberGenerator will be called every 5 billion nanoseconds i.e. every 5 seconds 
-until the program is killed.
+The Timer constructor takes 3 arguments, the class to notify, how long until our timer expires and how often to fire. In our example code an instance of NumberGenerator will be called every 5 billion nanoseconds i.e. every 5 seconds until the program is killed.
 
 Here's our method in NumberGenerator that gets executed:
 
@@ -67,7 +54,7 @@ Here's our method in NumberGenerator that gets executed:
     true
 ```
 
-If we were to compile and run our application, we'd end up with some output 
+If we were to compile and run our application, we'd end up with some output
 like:
 
 ```bash
@@ -82,17 +69,11 @@ $ ./timer
 
 ## Discussion
 
-It's not the most exciting output in the world but, it's a pattern that can
-be adapted to many different scenarios. Timer can be put to use for rate
-limiting outgoing network connections, creating buffers that flush at a set
-interval, implementing timeouts and variety of other time based _blocking_
-operations. 
+It's not the most exciting output in the world but, it's a pattern that can be adapted to many different scenarios. Timer can be put to use for rate limiting outgoing network connections, creating buffers that flush at a set interval, implementing timeouts and variety of other time based _blocking_ operations.
 
 ---
 
-This pattern is based on a 
-[blog post](http://www.monkeysnatchbanana.com/2016/01/18/pony-patterns-waiting/)
-previously published by Sean T. Allen.
+This pattern is based on a [blog post](http://www.monkeysnatchbanana.com/2016/01/18/pony-patterns-waiting/) previously published by Sean T. Allen.
 
 
 

--- a/performance/index.md
+++ b/performance/index.md
@@ -1,17 +1,10 @@
 # Performance
 
-Why are you interested in Pony? We bet at least a bit of your answer involves
-its promise of high performance code. When it comes to writing code that runs
-fast, Pony sets you up for sucess in a way that few languages do that said, you
-can still write slow code. 
+Why are you interested in Pony? We bet at least a bit of your answer involves its promise of high performance code. When it comes to writing code that runs fast, Pony sets you up for sucess in a way that few languages do that said, you can still write slow code.
 
-The patterns in this chapter aim to help teach you a variety of tricks to help
-you write fast code. Most of them will focus on one or both of the following:
+The patterns in this chapter aim to help teach you a variety of tricks to help you write fast code. Most of them will focus on one or both of the following:
 
 - Limit memory allocations
 - Limit the number of objects your create
 
-Neither of these techniques is unique to Pony. They are both fairly standard
-means of getting more performance from programs in any language. How you go
-about that is often specific to individual languages. Here's your entree getting
-the most out of Pony.
+Neither of these techniques is unique to Pony. They are both fairly standard means of getting more performance from programs in any language. How you go about that is often specific to individual languages. Here's your entree getting the most out of Pony.

--- a/performance/limiting-string-allocations.md
+++ b/performance/limiting-string-allocations.md
@@ -2,8 +2,7 @@
 
 ## Problem
 
-Your code is performance sensitive and need to make your `String` concatenation
-code as fast as possible.
+Your code is performance sensitive and need to make your `String` concatenation code as fast as possible.
 
 ## Solution
 
@@ -13,8 +12,7 @@ Replace any usage of `String.add` with `String.append`. Going from code like:
 let output = file_name + ":" + file_linenum + ":" + file_linepos + ": " + msg
 ```
 
-to `String.append` where we pre-allocate the memory needed to hold our final
-string.
+to `String.append` where we pre-allocate the memory needed to hold our final string.
 
 ```pony
 let output = recover String(file_name.size()
@@ -35,10 +33,7 @@ output
 
 ## Discussion
 
-If you want to make your Pony code go fast (and who doesn't want to go fast?),
-there are two simple steps you can take that will get you a lot of reward:
-reducing the number of objects you create and reducing the number of memory
-allocations. Our solution does both. 
+If you want to make your Pony code go fast (and who doesn't want to go fast?), there are two simple steps you can take that will get you a lot of reward: reducing the number of objects you create and reducing the number of memory allocations. Our solution does both.
 
 While String.add can be very convenient, it's a bit of a dog performance wise.
 
@@ -46,9 +41,7 @@ While String.add can be very convenient, it's a bit of a dog performance wise.
 let output = file_name + ":" + file_linenum + ":" + file_linepos + ": " + msg
 ```
 
-will create a new `String` and allocate memory for it on each `+`. In the case 
-of our example, that's six objects that get created and six different memory
-allocations. Our solution addresses both these issues. First, 
+will create a new `String` and allocate memory for it on each `+`. In the case  of our example, that's six objects that get created and six different memory allocations. Our solution addresses both these issues. First,
 
 ```pony
 let output = recover String(file_name.size()
@@ -58,8 +51,7 @@ let output = recover String(file_name.size()
   + 4) end
 ```
 
-allocates all the memory it is going to need in one go; cutting our memory
-total allocations by five. Then by using `append`
+allocates all the memory it is going to need in one go; cutting our memory total allocations by five. Then by using `append`
 
 ```
 output.append(file_name)
@@ -72,13 +64,8 @@ output.append(msg)
 output
 ```
 
-we don't create any additional objects. 
+we don't create any additional objects.
 
-All told, by switching from `String.add` to `String.append`, drop down to a
-single memory allocation and a single object being created. Replacing a single 
-use of `+` with `append` isn't going to get you much, however, if the code you
-are replacing is called a lot, it's going to be a huge win. In the case of our
-solution above, we took the code from the Pony `logger` package. Given how often
-logging methods get called, switching from `+` to `append` has a huge impact.
+All told, by switching from `String.add` to `String.append`, drop down to a single memory allocation and a single object being created. Replacing a single  use of `+` with `append` isn't going to get you much, however, if the code you are replacing is called a lot, it's going to be a huge win. In the case of our solution above, we took the code from the Pony `logger` package. Given how often logging methods get called, switching from `+` to `append` has a huge impact.
 
 

--- a/testing/index.md
+++ b/testing/index.md
@@ -1,13 +1,5 @@
 # Testing
 
-Most of us are familiar with unit testing code with more traditional concurrency
-models. In this case of threaded code, for many, this means throwing up your
-hands in disgust and walking away. Testing concurrency with threads is hard.
-Testing concurrency is Pony is much easier but if you haven't encountered
-anything like it before it can be hard to know where to start.
+Most of us are familiar with unit testing code with more traditional concurrency models. In this case of threaded code, for many, this means throwing up your hands in disgust and walking away. Testing concurrency with threads is hard. Testing concurrency is Pony is much easier but if you haven't encountered anything like it before it can be hard to know where to start.
 
-The patterns in this chapter will cover various ways of testing your Pony code.
-We will pay particular attention to how to test actors. Please note that this
-chapter assumes that you are familiar with the basics of using PonyTest, the
-Pony unit testing framework. If you aren't, please review the
-[PonyTest documentation](http://www.ponylang.org/ponyc/ponytest--index/).
+The patterns in this chapter will cover various ways of testing your Pony code. We will pay particular attention to how to test actors. Please note that this chapter assumes that you are familiar with the basics of using PonyTest, the Pony unit testing framework. If you aren't, please review the [PonyTest documentation](http://www.ponylang.org/ponyc/ponytest--index/).

--- a/testing/notifier-interactions.md
+++ b/testing/notifier-interactions.md
@@ -2,13 +2,7 @@
 
 ## Problem
 
-Event driven code is very common in Pony. Many classes take a "notifier" class
-that has callbacks that get triggered when certain events happen. The network
-code such as `UDPNotify` and `TCPNotify` are examples of this. As you write your
-own Pony code, the notifier pattern is one you'll end up using quite a bit.
-Testing that your code is correctly interacting with notifiers is
-straightforward; however, how you go about doing that isn't immediately obvious.
-Imagine for a moment that you have the following actor:
+Event driven code is very common in Pony. Many classes take a "notifier" class that has callbacks that get triggered when certain events happen. The network code such as `UDPNotify` and `TCPNotify` are examples of this. As you write your own Pony code, the notifier pattern is one you'll end up using quite a bit. Testing that your code is correctly interacting with notifiers is straightforward; however, how you go about doing that isn't immediately obvious. Imagine for a moment that you have the following actor:
 
 ```
 actor Receiver
@@ -21,18 +15,14 @@ actor Receiver
     _notify.received(this, msg)
 ```
 
-It's really simple. When it receives some string, it will pass its own identity
-and that string along to the object it is supposed to notify. What is the object
-it will notify? Anything that conforms to the interface
+It's really simple. When it receives some string, it will pass its own identity and that string along to the object it is supposed to notify. What is the object it will notify? Anything that conforms to the interface
 
 ```
 interface Notified
   fun ref received(rec: Receiver ref, msg: String)
 ```
 
-In our contrived, simplified example, we want to know that if we call `receive` 
-on the `Receiver` actor, then the string we call it with will end up being 
-passed to our notifier where we can process it. So, how do we go about that?
+In our contrived, simplified example, we want to know that if we call `receive`  on the `Receiver` actor, then the string we call it with will end up being  passed to our notifier where we can process it. So, how do we go about that?
 
 ## Solution
 
@@ -85,9 +75,7 @@ actor Receiver
 
 ## Discussion
 
-Notifiers work by using structual typing. We define an interface that the given
-notifier has to implement and then create concrete implementations. In our above
-solution, you can see this with:
+Notifiers work by using structual typing. We define an interface that the given notifier has to implement and then create concrete implementations. In our above solution, you can see this with:
 
 ```
 interface Notified
@@ -110,9 +98,7 @@ class TestNotifier is Notified
    _h.complete(true)
 ```
 
-Our test is verifying that our Receiver correctly uses the notifier and that 
-when we call `receive` on a `Receiver`, we pass the correct data to the 
-notifier's `received` method:
+Our test is verifying that our Receiver correctly uses the notifier and that  when we call `receive` on a `Receiver`, we pass the correct data to the  notifier's `received` method:
 
 ```
   fun ref received(rec: Receiver ref, msg: String) =>


### PR DESCRIPTION
This PR reformats markdown files to avoid hard wraps in favor of soft wrapping by our text editors and doc renderers.  It also makes this policy clear in `CONTRIBUTING.md`.

See some discussion here: https://github.com/ponylang/pony-for-x/pull/1#issuecomment-217628633