### PR TITLE
Correct order of arguments in code explanation

### DIFF
--- a/docs/async/waiting.md
+++ b/docs/async/waiting.md
@@ -49,7 +49,7 @@ Zooming in on the key bits, we first set up our timers, create one and add it to
     timers(consume timer)
 ```
 
-The Timer constructor takes 3 arguments, the class to notify, how long until our timer expires and how often to fire. In our example code, an instance of `NumberGenerator` will be called every 5 billion nanoseconds i.e. every 5 seconds until the program is killed.
+The Timer constructor takes 3 arguments, the class to notify, how often to fire and how long until our timer expires. In our example code, an instance of `NumberGenerator` will be called every 5 billion nanoseconds i.e. every 5 seconds until the program is killed.
 
 Here's our method in `NumberGenerator` that gets executed:
 


### PR DESCRIPTION
The order of the arguments in the text explaining the Timer constructor was incorrect