### PR TITLE
Address correctness issues in Supply Chain pattern

### DIFF
--- a/.spelling-wordlist.txt
+++ b/.spelling-wordlist.txt
@@ -12,6 +12,7 @@ mixin
 mixins
 namespace
 natively
+oof
 ponylang
 preallocate
 preallocating

--- a/docs/creation/supply-chain.md
+++ b/docs/creation/supply-chain.md
@@ -20,7 +20,7 @@ actor TempWriter
   new create(auth: FileAuth, file_name: String) =>
     let dir = FilePath.mkdtemp(auth)?
     let log = FilePath.from(dir, file_name)?
-    _file = File(dir)
+    _file = File(log)
 
   be record(it: String) =>
     _file.write(it)

--- a/docs/creation/supply-chain.md
+++ b/docs/creation/supply-chain.md
@@ -53,7 +53,7 @@ x.pony:14:10: couldn't find write in None val
          ^
 ```
 
-One more change address that `file` could be uninitialized:
+One more change addresses that `_file` could be uninitialized:
 
 ```pony
 use "files"

--- a/docs/creation/supply-chain.md
+++ b/docs/creation/supply-chain.md
@@ -26,7 +26,7 @@ actor TempWriter
     _file.write(it)
 ```
 
-We've already hit our first problem. Our above code won't compile. Why? Well, it doesn't handle errors. For starters, `FilePath.mkdtemp(auth)?` and `FilePath.from(dir, file_name)?` can both fail. We might not be able to create the directory.  If we were to address that, we would also need to address that our `File` object might not be able to be initialized. In order to deal with our errors, we'll need to make `file` be of type `(File | None)`. This union type states that we can have a file or nothing. An iteration to address this gets us almost all the way to being able to compile but not quite:
+We've already hit our first problem. Our above code won't compile. Why? Well, it doesn't handle errors. For starters, `FilePath.mkdtemp(auth)?` and `FilePath.from(dir, file_name)?` can both fail. We might not be able to create the directory. If we were to address that, we would also need to address that our `File` object might not be able to be initialized. In order to deal with our errors, we'll need to make `_file` be of type `(File | None)`. This union type states that we can have a file or nothing. An iteration to address this gets us almost all the way to being able to compile but not quite:
 
 ```pony
 use "files"

--- a/docs/creation/supply-chain.md
+++ b/docs/creation/supply-chain.md
@@ -74,7 +74,7 @@ actor TempWriter
     end
 ```
 
-With this change, in our `record` behavior, we match on `file` and only attempt to write if it is of type `File`. Awesome. We have working code. Except, ugh. There is are actually a couple problems still lurking.
+With this change, in our `record` behavior, we match on `_file` and only attempt to write if it is of type `File`. Awesome. We have working code. Except, ugh. There are actually a couple problems still lurking.
 
 First, while `File` doesn't return an error, it can fail. The `File` constructor docs state:
 


### PR DESCRIPTION
A user pointed out that we weren't address the fact that `File` can fail and that you need to check `errno()` to see if it worked. This makes the pattern incomplete and misleading.

When I was addressing this, I noticed that when I originally wrote the pattern, I was trying to write the temp directory without creating a file in it.

Both issues have been addressed in this update.

Closes #71