### PR TITLE
Fix compilation error in access pattern

### DIFF
--- a/docs/async/access.md
+++ b/docs/async/access.md
@@ -63,8 +63,8 @@ Now, let's say we want to do some higher-level operations on these registers, an
 ```pony
 actor Mathematician
   let _reg: SharedRegisters
-  let _out: StdStream
-  new create(reg: SharedRegisters, out: StdStream) =>
+  let _out: OutStream
+  new create(reg: SharedRegisters, out: OutStream) =>
     _reg = reg
     _out = out
 
@@ -157,8 +157,8 @@ Now let's take a look at a revised implementation of `Mathematician` that uses t
 ```pony
 actor Mathematician
   let _reg: SharedRegisters
-  let _out: StdStream
-  new create(reg: SharedRegisters, out: StdStream) =>
+  let _out: OutStream
+  new create(reg: SharedRegisters, out: OutStream) =>
     _reg = reg
     _out = out
 


### PR DESCRIPTION
The code for the access pattern when done originally 9 years ago was correct, however, 8 years ago it was broken when the following change was made:

https://github.com/ponylang/ponyc/commit/514d9c1d617923b6faabb3ddaf6d8622441b073a