### PR TITLE
Stop using mkdocs-material insiders build

### DIFF
--- a/.github/workflows/verify-site-builds.yml
+++ b/.github/workflows/verify-site-builds.yml
@@ -14,8 +14,6 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Install dependencies
         run: pip install -r requirements.txt
-        env:
-          INSIDERS_PAT: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
       - name: Build site
         run: mkdocs build
       - name: Send alert on failure

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://${INSIDERS_PAT}@github.com/squidfunk/mkdocs-material-insiders.git
+mkdocs-material
 mkdocs-htmlproofer-plugin>=0.1.0


### PR DESCRIPTION
It is all public now. https://squidfunk.github.io/mkdocs-material/blog/2025/11/11/insiders-now-free-for-everyone/.