### PR TITLE
Replace super-linter with dedicated linter images

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,4 +1,0 @@
-{
-  "MD013": false,
-  "MD026": false
-}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,19 +10,13 @@ permissions:
   packages: read
 
 jobs:
-  superlinter:
-    name: Lint markdown and yaml
+  lint-markdown:
+    name: Lint markdown
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v4.1.1
-      - name: Lint codebase
-        uses: docker://github/super-linter:v3.8.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true
-          VALIDATE_MD: true
-          VALIDATE_YAML: true
+      - uses: actions/checkout@v4.1.1
+      - name: Lint markdown
+        uses: docker://ghcr.io/ponylang/shared-docker-ci-markdownlint:20260810
 
   check-spelling:
     name: Spellcheck markdown

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,5 @@
+{
+  "MD013": false,
+  "MD026": false,
+  "MD051": false
+}

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,5 +1,6 @@
 {
   "MD013": false,
   "MD026": false,
+  "MD049": false,
   "MD051": false
 }


### PR DESCRIPTION
Replace the super-linter Docker image with a dedicated markdownlint image from shared-docker. Faster CI — small purpose-built image instead of the 2GB+ super-linter.